### PR TITLE
Pass a managed sub-agent's `agent_args` to the agent built for it

### DIFF
--- a/minion_agent/frameworks/minion.py
+++ b/minion_agent/frameworks/minion.py
@@ -121,6 +121,12 @@ class ExternalMinionAgent(MinionAgent):
                     if managed_agent.framework in (None, self.framework)
                     else {}
                 )
+                # Keys this call passes explicitly win; a duplicate in agent_args would
+                # otherwise raise TypeError (multiple values for a keyword argument).
+                managed_agent_args = {
+                    k: v for k, v in managed_agent_args.items()
+                    if k not in ("name", "model", "tools", "verbosity_level", "description")
+                }
                 managed_agent_instance = agent_type(
                     name=managed_agent.name,
                     model=self._get_model(managed_agent),

--- a/minion_agent/frameworks/minion.py
+++ b/minion_agent/frameworks/minion.py
@@ -113,6 +113,14 @@ class ExternalMinionAgent(MinionAgent):
                 managed_tools, _ = await self._load_tools(managed_agent.tools)
                 # Process managed agent tools as well
                 managed_tools = self._process_tools_for_minion(managed_tools)
+                # agent_args are specific to the framework that builds the agent, so
+                # they are only passed on when this config targets this framework
+                # (framework=None means the same one as the parent).
+                managed_agent_args = (
+                    managed_agent.agent_args or {}
+                    if managed_agent.framework in (None, self.framework)
+                    else {}
+                )
                 managed_agent_instance = agent_type(
                     name=managed_agent.name,
                     model=self._get_model(managed_agent),
@@ -120,6 +128,7 @@ class ExternalMinionAgent(MinionAgent):
                     verbosity_level=2,
                     description=managed_agent.description
                                 or f"Use the agent: {managed_agent.name}",
+                    **managed_agent_args,
                 )
                 if managed_agent.instructions:
                     managed_agent_instance.prompt_templates["system_prompt"] = (

--- a/minion_agent/frameworks/smolagents.py
+++ b/minion_agent/frameworks/smolagents.py
@@ -66,6 +66,12 @@ class SmolagentsAgent(MinionAgent):
                     if managed_agent.framework in (None, self.framework)
                     else {}
                 )
+                # Keys this call passes explicitly win; a duplicate in agent_args would
+                # otherwise raise TypeError (multiple values for a keyword argument).
+                managed_agent_args = {
+                    k: v for k, v in managed_agent_args.items()
+                    if k not in ("name", "model", "tools", "verbosity_level", "description")
+                }
                 managed_agent_instance = agent_type(
                     name=managed_agent.name,
                     model=self._get_model(managed_agent),

--- a/minion_agent/frameworks/smolagents.py
+++ b/minion_agent/frameworks/smolagents.py
@@ -58,6 +58,14 @@ class SmolagentsAgent(MinionAgent):
             for managed_agent in self.managed_agents:
                 agent_type = managed_agent.agent_type or DEFAULT_AGENT_TYPE
                 managed_tools, _ = await self._load_tools(managed_agent.tools)
+                # agent_args are specific to the framework that builds the agent, so
+                # they are only passed on when this config targets this framework
+                # (framework=None means the same one as the parent).
+                managed_agent_args = (
+                    managed_agent.agent_args or {}
+                    if managed_agent.framework in (None, self.framework)
+                    else {}
+                )
                 managed_agent_instance = agent_type(
                     name=managed_agent.name,
                     model=self._get_model(managed_agent),
@@ -65,6 +73,7 @@ class SmolagentsAgent(MinionAgent):
                     verbosity_level=2,
                     description=managed_agent.description
                     or f"Use the agent: {managed_agent.name}",
+                    **managed_agent_args,
                 )
                 if managed_agent.instructions:
                     managed_agent_instance.prompt_templates["system_prompt"] = (

--- a/tests/test_managed_agent_args.py
+++ b/tests/test_managed_agent_args.py
@@ -1,0 +1,83 @@
+"""A managed sub-agent's `agent_args` must reach the agent that is built for it.
+
+The parent splats `self.config.agent_args` into its own constructor, so settings
+such as `max_steps` and `additional_authorized_imports` are honoured there. The
+same keys on a managed sub-agent are only honoured if they are splatted into the
+sub-agent's constructor too.
+"""
+
+import asyncio
+
+import pytest
+from smolagents import CodeAgent
+
+from minion_agent import AgentConfig, AgentFramework, MinionAgent
+
+
+class _OfflineModel:
+    """A model stand-in: constructed, never called, so the test needs no network."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def generate(self, *args, **kwargs):  # pragma: no cover - never reached
+        raise AssertionError("the test never runs the agent")
+
+
+def _config(name, agent_args=None):
+    return AgentConfig(
+        model_id="offline/none",
+        name=name,
+        description=f"{name} agent",
+        agent_type=CodeAgent,
+        model_type=lambda **kwargs: _OfflineModel(**kwargs),
+        tools=[],
+        agent_args=agent_args,
+    )
+
+
+def test_managed_agent_args_reach_the_sub_agent():
+    agent = asyncio.run(
+        MinionAgent.create_async(
+            AgentFramework.SMOLAGENTS,
+            _config("supervisor"),
+            managed_agents=[
+                _config(
+                    "worker",
+                    {"max_steps": 3, "additional_authorized_imports": ["json"]},
+                )
+            ],
+        )
+    )
+    child = agent._agent.managed_agents["worker"]
+    assert child.max_steps == 3
+    assert "json" in child.additional_authorized_imports
+
+
+def test_parent_agent_args_are_unchanged():
+    agent = asyncio.run(
+        MinionAgent.create_async(
+            AgentFramework.SMOLAGENTS,
+            _config("supervisor", {"max_steps": 5}),
+        )
+    )
+    assert agent._agent.max_steps == 5
+
+
+def test_agent_args_for_another_framework_are_not_passed_on():
+    """A managed config that targets a different framework keeps its own args.
+
+    `example_deep_research.py` reuses one AgentConfig both to build a
+    DEEP_RESEARCH agent and as a managed agent under a SMOLAGENTS parent. Its
+    `agent_args` name deep-research models, which the smolagents agent class
+    does not accept.
+    """
+    research = _config("research_assistant", {"planning_model": "some/model"})
+    research.framework = AgentFramework.DEEP_RESEARCH
+
+    agent = asyncio.run(
+        MinionAgent.create_async(
+            AgentFramework.SMOLAGENTS, _config("supervisor"), managed_agents=[research]
+        )
+    )
+    assert "research_assistant" in agent._agent.managed_agents

--- a/tests/test_managed_agent_args.py
+++ b/tests/test_managed_agent_args.py
@@ -9,7 +9,9 @@ sub-agent's constructor too.
 import asyncio
 
 import pytest
-from smolagents import CodeAgent
+
+smolagents = pytest.importorskip("smolagents")
+CodeAgent = smolagents.CodeAgent
 
 from minion_agent import AgentConfig, AgentFramework, MinionAgent
 
@@ -81,3 +83,24 @@ def test_agent_args_for_another_framework_are_not_passed_on():
         )
     )
     assert "research_assistant" in agent._agent.managed_agents
+
+
+def test_keys_the_builder_passes_explicitly_do_not_collide():
+    """`agent_args` may name a key the builder also passes (`description`,
+    `verbosity_level`, ...). The builder's value wins and the agent still loads,
+    instead of `TypeError: got multiple values for keyword argument`."""
+    agent = asyncio.run(
+        MinionAgent.create_async(
+            AgentFramework.SMOLAGENTS,
+            _config("supervisor"),
+            managed_agents=[
+                _config(
+                    "worker",
+                    {"max_steps": 3, "description": "ignored", "verbosity_level": 0},
+                )
+            ],
+        )
+    )
+    child = agent._agent.managed_agents["worker"]
+    assert child.max_steps == 3
+    assert child.description != "ignored"


### PR DESCRIPTION
I maintain attenu-guard (https://github.com/attenu-io/attenu-guard) and found this while running it against minion-agent. Issue: #6.

`SmolagentsAgent._load_agent` builds each managed sub-agent without `managed_agent.agent_args`, so `executor_type`, `max_steps` and `additional_authorized_imports` set on a sub-agent are discarded. The parent splats its own at `smolagents.py:84`, and the agno, langchain and llama_index backends splat the child's. `frameworks/minion.py` has the same gap. This patch passes the child's `agent_args` at both call sites.

They are passed only when `managed_agent.framework` is unset or matches this backend, the way `deep_research.py:752` already discriminates. `example_deep_research.py` reuses one `AgentConfig` as a DEEP_RESEARCH agent and as a managed agent under a SMOLAGENTS parent; an unconditional splat raises a `TypeError` there on `planning_model`. If you prefer the plain splat plus a fix to that example, tell me.

`tests/test_managed_agent_args.py` adds three cases; the first fails on `main` with `assert 20 == 3`. `python -m pytest` goes from 7 failed / 8 passed to 7 failed / 11 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Managed sub-agents now receive their `agent_args` when the parent builds them, so settings like `max_steps` and `additional_authorized_imports` are no longer silently dropped.

- Applies the fix in both `minion_agent/frameworks/smolagents.py` and `minion_agent/frameworks/minion.py`.
- Passes the args only when the sub-agent's framework is unset or matches the parent's, avoiding a `TypeError` when a config is reused across frameworks (like `example_deep_research.py`).
- Explicitly passed keys like `name` and `description` win over `agent_args` duplicates, which would otherwise raise a `TypeError`.
- Adds `tests/test_managed_agent_args.py` covering pass-through, unchanged parent args, the cross-framework case, and key collisions; the suite skips when `smolagents` is not installed.

<sup>Written for commit 65f375b3006cdfd90e9425dd69b8efa2ffd0f1cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/femto/minion-agent/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

